### PR TITLE
Running pear outside of a git repo handled

### DIFF
--- a/pear
+++ b/pear
@@ -8,8 +8,6 @@ pear_dir=$(cd $(dirname $0); pwd)
 pear_commands_dir=$pear_dir/libexec
 usage_command=$pear_commands_dir/usage
 
-# Exported for use in other programs... coupled too tightly?
-export PEAR_WORKING_DIR=$(cd $(git rev-parse --show-toplevel); pwd)
 
 
 # Alias command to the first arg
@@ -17,6 +15,15 @@ command=$1
 
 # The full path to the intended command
 command_path=$pear_commands_dir/$command
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Pear adds pairs to local git directories only."
+  echo "Please try using pear in a git repository"
+  exit 1
+else
+  # Exported for use in other programs... coupled too tightly?
+  export PEAR_WORKING_DIR=$(cd $(git rev-parse --show-toplevel); pwd)
+fi
 
 # If no command was given then print usage and exit
 test -n "$command" || {


### PR DESCRIPTION
pear outside of a repo tells the user it only works inside a repo
we also only run the code that sets the git dir inside a git repo
this hides the error it would throw ourside of a git dir

closes #9 

![screen shot 2014-07-04 at 8 57 28 am](https://cloud.githubusercontent.com/assets/2591516/3483729/65de1de4-0394-11e4-9961-a9b227de09dc.png)
