### PR TITLE
Cycle now cycles as intended.

### DIFF
--- a/libexec/cycle
+++ b/libexec/cycle
@@ -2,7 +2,7 @@
 
 git_dir=$(git rev-parse --git-dir)
 team=$PEAR_WORKING_DIR"/$git_dir/team.txt"
-committer=$(source $PEAR_WORKING_DIR/libexec/get-committer)
+author=$(pear get-author)
 
 sed -i '' -e '1d' $team
-echo $committer >> $team
+echo $author >> $team


### PR DESCRIPTION
Old function was overwriting the first line with the second line
ignore to the git config lines, this shows before and after functions of pear cycle 

![screen shot 2014-07-08 at 9 40 12 am](https://cloud.githubusercontent.com/assets/2591516/3512975/cab0668c-06be-11e4-8f9d-cd1253019745.png)
