### PR TITLE
Set author name in git commit to avoid fatal error

### DIFF
--- a/libexec/set-author-committer
+++ b/libexec/set-author-committer
@@ -11,4 +11,4 @@ author=$(pear get-author)
 pear cycle
 
 # The commit line must run last as it essentially exits this pre-commit
-git commit --author=$author --no-verify
+git commit --author="Pear <$author>" --no-verify


### PR DESCRIPTION
Fixes #29 
