### PR TITLE
Outside git fix

### DIFF
--- a/pear
+++ b/pear
@@ -20,6 +20,7 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
   echo "Please try using pear in a git repository"
   exit 1
 else
+  # Cannot set git dir earlier or the usage will not display correctly
   git_dir=$(git rev-parse --git-dir)
   # Exported for use in other programs... coupled too tightly?
   export PEAR_WORKING_DIR=$(cd $(git rev-parse --show-toplevel); pwd)


### PR DESCRIPTION
closes #39 

There was a git call before the git usage check.  Moved that call to the else of the if statement that looks for git

![1245228598_jet_ski_backflip](https://cloud.githubusercontent.com/assets/2591516/3591804/844887f6-0c68-11e4-9756-74145d1b6a2e.gif)
