### PR TITLE
Install checks for bin not pear

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test -f /usr/local/bin/ && {
+test -d /usr/local/bin/ && {
     rm -rf /usr/local/bin/pear
     ln -s $PWD/pear /usr/local/bin/
 


### PR DESCRIPTION
Old install check checks for the pear directory. (also it was failing on fresh installs)
This is not cool, new check looks for usr/local/bin :)
