### PR TITLE
Removes team section during cycle.  No longer unsets team

### DIFF
--- a/libexec/cycle
+++ b/libexec/cycle
@@ -13,10 +13,10 @@ emails=$(echo ${emails##$author})
 emails=$(echo $emails $author)
 
 # Reset pear emails
-git config --local --unset-all team.emails
+git config --local --remove-section team
 
 # Convert whitespace to newlines & loop through
-echo $emails | tr " " "\n" | while read line; do 
+echo $emails | tr " " "\n" | while read line; do
   # Add emails to pear emails key
   git config --local --add team.emails $line
 done


### PR DESCRIPTION
image after 3 test commits and cycles
![screen shot 2014-09-03 at 10 22 26 am](https://cloud.githubusercontent.com/assets/2591516/4138244/658be328-338f-11e4-8921-fe4a60226b3a.png)
Coded to 20syl
Closes #51 

![keys](https://cloud.githubusercontent.com/assets/2591516/4138238/5b40e7a6-338f-11e4-8b96-d07c738772f9.jpg)
